### PR TITLE
Add automated PR triage workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,12 @@
+name: Triage PR
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  triage:
+    uses: TicketsBot-cloud/template/.github/workflows/auto-label.yaml@main
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
Adds `.github/workflows/triage.yml` which calls the reusable auto-label workflow from the template repo.

This will automatically label PRs based on:
- **`needs:bump_db`** / **`needs:bump_common`** — when the PR description links to database or common repo PRs
- **`needs:gomod_comment`** — when `go.mod` has uncommented local replace directives
- **`type:bug`** / **`type:feature`** / **`type:breaking`** — based on the PR description checkboxes